### PR TITLE
fix: patch tool

### DIFF
--- a/deep_research_agent/analyze_and_search.py
+++ b/deep_research_agent/analyze_and_search.py
@@ -14,7 +14,6 @@ def analyze_and_search_tool(agent_state: "AgentState", summary: str, gaps: List[
     import requests
     import json
     import os
-    from concurrent.futures import ThreadPoolExecutor
 
     # Input validation
     if not next_search_topic or not isinstance(next_search_topic, str):


### PR DESCRIPTION
Clean up the main deep research tool to throw clean errors when the API keys don't exist, which should help the end-user realize why the tool is failing.

e.g.:
<img width="487" alt="image" src="https://github.com/user-attachments/assets/3fbcc50e-caed-4a91-bc93-4a76e4d4c9c6" />
