### PR TITLE
feat: add Contribute link to header navigation

### DIFF
--- a/src/lib/client/components/Header/Header.tsx
+++ b/src/lib/client/components/Header/Header.tsx
@@ -54,6 +54,11 @@ export function Header(props: HeaderProps) {
         <HStack gap="large" align="center">
           <HeaderLink
             color={variant === 'white' ? 'white' : 'default'}
+            label={"Contribute"}
+            href="https://github.com/letta-ai/agent-file/blob/main/agents/CONTRIBUTING.md"
+          />
+          <HeaderLink
+            color={variant === 'white' ? 'white' : 'default'}
             label={"Docs"}
             href="https://docs.letta.com/"
           />


### PR DESCRIPTION
## Summary
Add prominent "Contribute" link to the header navigation so users can easily find how to contribute agents.

## Changes
- Added "Contribute" link to Header.tsx, positioned first in navigation
- Links directly to the contributing guide on GitHub

## Test plan
- [ ] Verify "Contribute" link appears in header
- [ ] Verify link opens contributing guide

"The best way to predict the future is to create it." — Alan Kay

Written by Cameron ◯ Letta Code